### PR TITLE
fix: ignore node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .env
-node_mdules
+node_modules


### PR DESCRIPTION
## Summary
- ignore node_modules directory

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6894d0daf53c83209a2f0a9ed3b6a048