### PR TITLE
Enforce bootstrap balance threshold

### DIFF
--- a/contracts/GPDIndex0Bootloader.sol
+++ b/contracts/GPDIndex0Bootloader.sol
@@ -146,7 +146,10 @@ contract GPDIndex0Bootloader {
 
     function _triggerBootstrap() internal {
         require(!triggered, "Already triggered");
-        require(address(this).balance > 0, "No AVAX balance");
+        require(
+            address(this).balance >= bootstrapThreshold,
+            "Balance below bootstrap threshold"
+        );
 
         triggered = true;
         emit BootstrapTriggered();


### PR DESCRIPTION
## Summary
- require contract balance to meet `bootstrapThreshold` before triggering bootstrap

## Testing
- `npx hardhat compile` (fails: Invalid account: #0 for network: avalanche - private key too short)

------
https://chatgpt.com/codex/tasks/task_e_6894d0d7258483208015b244519ca483