### PR TITLE
feat: add ownership transferred event to bootloader

### DIFF
--- a/contracts/GPDIndex0Bootloader.sol
+++ b/contracts/GPDIndex0Bootloader.sol
@@ -32,6 +32,7 @@ contract GPDIndex0Bootloader {
     using SafeERC20 for IERC20;
 
     // Events
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event TokenPurchased(address indexed token, uint256 amount, string dex);
     event LiquidityAdded(address indexed lpToken, address token, uint256 amount, string dex);
     event LPCreated(string pair);
@@ -96,7 +97,9 @@ contract GPDIndex0Bootloader {
 
     function transferOwnership(address newOwner) external onlyOwner {
         require(newOwner != address(0), "New owner cannot be zero address");
+        address previousOwner = owner;
         owner = newOwner;
+        emit OwnershipTransferred(previousOwner, newOwner);
     }
 
     function setGovernanceEnabled(bool enabled) external onlyOwner {


### PR DESCRIPTION
## Summary
- add `OwnershipTransferred` event to `GPDIndex0Bootloader`
- emit event when changing `owner` via `transferOwnership`

## Testing
- `npx hardhat test` *(fails: Member "safeApprove" not found or not visible after argument-dependent lookup in contract IERC20)*

------
https://chatgpt.com/codex/tasks/task_e_6894ceeed0e08320970044d21c546f58