### PR TITLE
Require minimum balance for bootstrap

### DIFF
--- a/contracts/GPDIndex0Bootloader.sol
+++ b/contracts/GPDIndex0Bootloader.sol
@@ -146,7 +146,10 @@ contract GPDIndex0Bootloader {
 
     function _triggerBootstrap() internal {
         require(!triggered, "Already triggered");
-        require(address(this).balance > 0, "No AVAX balance");
+        require(
+            address(this).balance >= bootstrapThreshold,
+            "AVAX balance below bootstrap threshold"
+        );
 
         triggered = true;
         emit BootstrapTriggered();


### PR DESCRIPTION
## Summary
- ensure `_triggerBootstrap` only runs when contract AVAX balance meets `bootstrapThreshold`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx hardhat compile` *(fails: Invalid account in config: private key too short)*

------
https://chatgpt.com/codex/tasks/task_e_6894ceebd6e4832096f5cadd9359e561